### PR TITLE
Allows teacher to message a chat

### DIFF
--- a/src/components/pages/StudentsPage/Chatbox.css.tsx
+++ b/src/components/pages/StudentsPage/Chatbox.css.tsx
@@ -4,7 +4,7 @@ const chatboxContainer = css`
   width: 500px;
 
   @media (max-width: 500px) {
-   /* widens the chatbox to more easily type messages on mobile */
+    /* widens the chatbox to more easily type messages on mobile */
     width: 120%;
     margin-left: -13px;
     margin-right: -13px;

--- a/src/components/pages/StudentsPage/Conversation.css.tsx
+++ b/src/components/pages/StudentsPage/Conversation.css.tsx
@@ -16,6 +16,11 @@ const peer = css`
   color: red;
 `;
 
+const teacher = css`
+  font-weight: bold;
+  color: purple;
+`;
+
 const msg = css`
   word-break: break-word;
 `;
@@ -24,6 +29,7 @@ const conversationCSS = {
   introText,
   peer,
   you,
+  teacher,
   msg,
 };
 

--- a/src/components/pages/StudentsPage/Conversation.tsx
+++ b/src/components/pages/StudentsPage/Conversation.tsx
@@ -11,16 +11,25 @@ export default function Conversation({ socket, chat, setChat }) {
   const lastMessage = useRef(null);
   useEffect(() => {
     if (socket) {
-      socket.on('chat message', ({ character, message }) => {
+      socket.on('student sent message', ({ character, message }) => {
         setChat((chat) => ({
           ...chat,
           conversation: [...chat.conversation, ['peer', character, message]],
         }));
       });
+      socket.on('teacher sent message', ({ message }) => {
+        setChat((chat) => ({
+          ...chat,
+          conversation: [...chat.conversation, ['teacher', 'TEACHER', message]],
+        }));
+      });
     }
 
     return () => {
-      if (socket) socket.off('chat message');
+      if (socket) {
+        socket.off('student sent message');
+        socket.off('teacher sent message');
+      }
     };
   }, [setChat, socket]);
 
@@ -44,6 +53,8 @@ export default function Conversation({ socket, chat, setChat }) {
         let fontCSS = {};
         if (person === 'peer') fontCSS = conversationCSS.peer;
         else if (person === 'you') fontCSS = conversationCSS.you;
+        else if (person === 'teacher') fontCSS = conversationCSS.teacher;
+
         return (
           <Typography key={i}>
             <span css={fontCSS}>{filterWords(character)}: </span>

--- a/src/components/pages/StudentsPage/SendMessages.tsx
+++ b/src/components/pages/StudentsPage/SendMessages.tsx
@@ -27,7 +27,7 @@ export default function SendMessages({ socket, chat, setChat }) {
         setChatEndedMsg(null);
       });
 
-      socket.on('chat message', () => {
+      socket.on('student sent message', () => {
         setPeerIsTyping(false);
       });
 
@@ -43,7 +43,7 @@ export default function SendMessages({ socket, chat, setChat }) {
       if (socket) {
         socket.off('peer left chat');
         socket.off('chat start');
-        socket.off('chat message');
+        socket.off('student sent message');
         socket.off('peer is typing');
       }
     };
@@ -51,7 +51,6 @@ export default function SendMessages({ socket, chat, setChat }) {
 
   function sendMessage(e) {
     e.preventDefault();
-    console.log('sendMessages form submitted!!');
     if (chat.you && message) {
       setChat((chat) => ({
         ...chat,
@@ -60,7 +59,7 @@ export default function SendMessages({ socket, chat, setChat }) {
       setMessage('');
 
       if (socket) {
-        socket.emit('chat message', {
+        socket.emit('student sent message', {
           character: chat.you,
           message,
         });

--- a/src/components/pages/TeachersPage/AllStudentChatsDisplay.tsx
+++ b/src/components/pages/TeachersPage/AllStudentChatsDisplay.tsx
@@ -36,9 +36,11 @@ export default function AllStudentChatsDisplay({
             onClick={() => setDisplayedChat(chat.chatId)}
           >
             <Chatbox
+              socket={null}
               chat={shortenedChat}
               inAllStudentChatsDisplay={true}
               isTheDisplayedChat={chat.chatId === displayedChat}
+              setStudentChats={null}
             />
           </Grid>
         );

--- a/src/components/pages/TeachersPage/Chatbox.css.tsx
+++ b/src/components/pages/TeachersPage/Chatbox.css.tsx
@@ -6,16 +6,24 @@ const chatboxContainer = css`
 
 const chatboxTop = css`
   background: #f8e5e0;
-  border-radius: 10px 10px 10px 10px;
+  border-radius: 10px 10px 0 0;
   min-height: 260px;
   padding: 10px;
   max-height: 260px;
   overflow-y: overlay;
 `;
 
+const chatboxBottom = css`
+  border-radius: 0 0 10px 10px;
+  padding: 0 0 10px 0;
+  text-align: center;
+  background: #f8e5e0;
+`;
+
 const chatboxCSS = {
   chatboxContainer,
   chatboxTop,
+  chatboxBottom,
 };
 
 export default chatboxCSS;

--- a/src/components/pages/TeachersPage/Chatbox.tsx
+++ b/src/components/pages/TeachersPage/Chatbox.tsx
@@ -5,11 +5,14 @@ import { Box } from '@mui/material';
 import chatboxCSS from './Chatbox.css';
 import Conversation from './Conversation';
 import CopyButton from '@components/shared/CopyButton';
+import SendMessages from './SendMessages';
 
 export default function Chatbox({
+  socket,
   chat,
   isTheDisplayedChat,
   inAllStudentChatsDisplay,
+  setStudentChats,
 }) {
   return (
     <Box css={chatboxCSS.chatboxContainer}>
@@ -27,6 +30,17 @@ export default function Chatbox({
           inAllStudentChatsDisplay={inAllStudentChatsDisplay}
         />
       </Box>
+
+      {/* Include send messages component if its the primary displayed chat */}
+      {isTheDisplayedChat && !inAllStudentChatsDisplay && (
+        <Box css={chatboxCSS.chatboxBottom}>
+          <SendMessages
+            socket={socket}
+            chatId={chat.chatId}
+            setStudentChats={setStudentChats}
+          />
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/components/pages/TeachersPage/Conversation.css.tsx
+++ b/src/components/pages/TeachersPage/Conversation.css.tsx
@@ -16,6 +16,11 @@ const student2 = css`
   color: red;
 `;
 
+const teacher = css`
+  font-weight: bold;
+  color: purple;
+`;
+
 const msg = css`
   word-break: break-word;
 `;
@@ -24,6 +29,7 @@ const conversationCSS = {
   introText,
   student1,
   student2,
+  teacher,
   msg,
 };
 

--- a/src/components/pages/TeachersPage/Conversation.tsx
+++ b/src/components/pages/TeachersPage/Conversation.tsx
@@ -33,6 +33,7 @@ export default function Conversation({ chat, inAllStudentChatsDisplay }) {
         let fontCSS = {};
         if (person === 'student1') fontCSS = conversationCSS.student1;
         else if (person === 'student2') fontCSS = conversationCSS.student2;
+        else if (person === 'teacher') fontCSS = conversationCSS.teacher;
 
         return (
           <Typography key={i}>

--- a/src/components/pages/TeachersPage/SendMessages.css.tsx
+++ b/src/components/pages/TeachersPage/SendMessages.css.tsx
@@ -1,0 +1,28 @@
+import { css } from '@emotion/react';
+
+const teacherName = css`
+  text-align: center;
+  color: purple;
+  font-weight: bold;
+  font-size: 18px;
+`;
+
+// TODO: This "message" css is identical to the one in StudentsPage/SendMessages.css.  It can be refactored to be only defined once.
+const message = css`
+  border-radius: 20px;
+  border: 2px solid lightgrey;
+  height: 50px;
+  margin-top: 8px;
+  width: 84%;
+  font-size: 17px;
+  padding-left: 20px;
+
+  :focus {
+    outline: none;
+    border: 3px solid deepskyblue;
+  }
+`;
+
+const sendMessagesCSS = { teacherName, message };
+
+export default sendMessagesCSS;

--- a/src/components/pages/TeachersPage/SendMessages.tsx
+++ b/src/components/pages/TeachersPage/SendMessages.tsx
@@ -27,7 +27,6 @@ export default function SendMessages({ socket, chatId, setStudentChats }) {
 
       if (socket) {
         socket.emit('teacher sent message', {
-          character: 'TEACHER',
           message,
           chatId,
         });

--- a/src/components/pages/TeachersPage/SendMessages.tsx
+++ b/src/components/pages/TeachersPage/SendMessages.tsx
@@ -1,0 +1,63 @@
+/** @jsxImportSource @emotion/react */
+
+import { Box, Fab, Typography } from '@mui/material';
+import { Send as SendIcon } from '@mui/icons-material';
+import { useState } from 'react';
+import sendMessagesCSS from './SendMessages.css';
+import { ChatMessage } from '.';
+
+export default function SendMessages({ socket, chatId, setStudentChats }) {
+  const [message, setMessage] = useState('');
+
+  function sendMessage(e) {
+    e.preventDefault();
+    if (message) {
+      setStudentChats((studentChats) => {
+        return studentChats.map((chat) => {
+          if (chat.chatId === chatId) {
+            const newMessage: ChatMessage = ['teacher', 'TEACHER', message];
+            return {
+              ...chat,
+              conversation: [...chat.conversation, newMessage],
+            };
+          } else return chat;
+        });
+      });
+      setMessage('');
+
+      if (socket) {
+        socket.emit('teacher sent message', {
+          character: 'TEACHER',
+          message,
+          chatId,
+        });
+      }
+    }
+  }
+
+  return (
+    <Box>
+      <form onSubmit={sendMessage}>
+        <Typography css={sendMessagesCSS.teacherName}>Teacher</Typography>
+
+        <input
+          css={sendMessagesCSS.message}
+          value={message}
+          placeholder='Say something'
+          maxLength={75}
+          onChange={(e) => setMessage(e.target.value)}
+          autoFocus
+        />
+
+        <Fab
+          size='small'
+          type='submit'
+          color='primary'
+          style={{ marginLeft: '10px', background: '#940000' }}
+        >
+          <SendIcon />
+        </Fab>
+      </form>
+    </Box>
+  );
+}


### PR DESCRIPTION
Resolves issue #5 
Server side PR: https://github.com/Frempco/web-server/pull/3

- Adds input on teachers page for teacher to message the primary displayed chat
- The teacher message displays on both the teachers and the students view of the chat
- Also renamed the names of existing socket chat messaging events to be more self-explanatory

Teachers page:
![image](https://user-images.githubusercontent.com/29524485/219053694-187900bd-c35b-4146-827b-4b6b0e551f81.png)

Students page:
![image](https://user-images.githubusercontent.com/29524485/219054051-355e3f6b-ac87-4688-9ee6-9dc8ef0317cc.png)